### PR TITLE
feat: add CorsOptions interface and Spring MVC CorsFilter with env-variable-backed configuration

### DIFF
--- a/Rest-api/src/main/java/it/water/service/rest/api/options/CorsOptions.java
+++ b/Rest-api/src/main/java/it/water/service/rest/api/options/CorsOptions.java
@@ -19,20 +19,16 @@ import it.water.core.api.service.Service;
 
 /**
  * @Author Aristide Cittadino
- * Class which maps all the rest available options
+ * Class which maps all CORS available options
  */
-public interface RestOptions extends Service {
-    String frontendUrl();
+public interface CorsOptions extends Service {
+    String allowedOrigins();
 
-    String servicesUrl();
+    String allowedMethods();
 
-    String restRootContext();
+    String allowedHeaders();
 
-    String uploadFolderPath();
+    boolean allowCredentials();
 
-    long uploadMaxFileSize();
-
-    JwtSecurityOptions securityOptions();
-
-    CorsOptions corsOptions();
+    long maxAge();
 }

--- a/Rest-service/src/main/java/it/water/service/rest/CorsOptionsImpl.java
+++ b/Rest-service/src/main/java/it/water/service/rest/CorsOptionsImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Aristide Cittadino
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package it.water.service.rest;
+
+import it.water.core.api.bundle.ApplicationProperties;
+import it.water.core.interceptors.annotations.FrameworkComponent;
+import it.water.core.interceptors.annotations.Inject;
+import it.water.service.rest.api.options.CorsOptions;
+import lombok.Setter;
+
+/**
+ * @Author Aristide Cittadino
+ * Default implementation of CorsOptions. Values are loaded from application properties
+ * with sensible defaults.
+ */
+@FrameworkComponent
+public class CorsOptionsImpl implements CorsOptions {
+
+    @Inject
+    @Setter
+    private ApplicationProperties applicationProperties;
+
+    @Override
+    public String allowedOrigins() {
+        Object val = applicationProperties.getProperty(RestConstants.REST_PROP_CORS_ORIGINS);
+        return val != null ? String.valueOf(val) : "*";
+    }
+
+    @Override
+    public String allowedMethods() {
+        Object val = applicationProperties.getProperty(RestConstants.REST_PROP_CORS_METHODS);
+        return val != null ? String.valueOf(val) : "GET,POST,PUT,DELETE,OPTIONS,PATCH";
+    }
+
+    @Override
+    public String allowedHeaders() {
+        Object val = applicationProperties.getProperty(RestConstants.REST_PROP_CORS_HEADERS);
+        return val != null ? String.valueOf(val) : "Authorization,Content-Type";
+    }
+
+    @Override
+    public boolean allowCredentials() {
+        Object val = applicationProperties.getProperty(RestConstants.REST_PROP_CORS_CREDENTIALS);
+        return val != null ? Boolean.parseBoolean(String.valueOf(val)) : true;
+    }
+
+    @Override
+    public long maxAge() {
+        Object val = applicationProperties.getProperty(RestConstants.REST_PROP_CORS_MAX_AGE);
+        return val != null ? Long.parseLong(String.valueOf(val)) : 3600L;
+    }
+}

--- a/Rest-service/src/main/java/it/water/service/rest/RestConstants.java
+++ b/Rest-service/src/main/java/it/water/service/rest/RestConstants.java
@@ -25,4 +25,10 @@ public class RestConstants {
     public static final String REST_PROP_ROOT_CONTEXT = "water.rest.root.context";
     public static final String REST_PROP_UPLOAD_PATH = "water.rest.uploadFolder.path";
     public static final String REST_PROP_UPLOAD_MAX_FILE_SIZE = "water.rest.uploadFolder.maxFileSize";
+
+    public static final String REST_PROP_CORS_ORIGINS = "water.rest.cors.origins";
+    public static final String REST_PROP_CORS_METHODS = "water.rest.cors.methods";
+    public static final String REST_PROP_CORS_HEADERS = "water.rest.cors.headers";
+    public static final String REST_PROP_CORS_CREDENTIALS = "water.rest.cors.credentials";
+    public static final String REST_PROP_CORS_MAX_AGE = "water.rest.cors.maxAge";
 }

--- a/Rest-service/src/main/java/it/water/service/rest/RestOptionsImpl.java
+++ b/Rest-service/src/main/java/it/water/service/rest/RestOptionsImpl.java
@@ -18,6 +18,7 @@ package it.water.service.rest;
 import it.water.core.api.bundle.ApplicationProperties;
 import it.water.core.interceptors.annotations.FrameworkComponent;
 import it.water.core.interceptors.annotations.Inject;
+import it.water.service.rest.api.options.CorsOptions;
 import it.water.service.rest.api.options.JwtSecurityOptions;
 import it.water.service.rest.api.options.RestOptions;
 import lombok.Getter;
@@ -34,6 +35,11 @@ public class RestOptionsImpl implements RestOptions {
     @Setter
     @Getter
     private JwtSecurityOptions jwtSecurityOptions;
+
+    @Inject
+    @Setter
+    @Getter
+    private CorsOptions corsOptions;
 
     @Inject
     @Setter
@@ -77,5 +83,10 @@ public class RestOptionsImpl implements RestOptions {
     @Override
     public JwtSecurityOptions securityOptions() {
         return getJwtSecurityOptions();
+    }
+
+    @Override
+    public CorsOptions corsOptions() {
+        return getCorsOptions();
     }
 }

--- a/Rest-service/src/main/java/it/water/service/rest/jackson/WaterJsonDeserializer.java
+++ b/Rest-service/src/main/java/it/water/service/rest/jackson/WaterJsonDeserializer.java
@@ -39,10 +39,11 @@ public class WaterJsonDeserializer extends JsonDeserializer<Object> implements C
             result = objectMapper.readerWithView(activeView).readValue(p, this.currentEntityType);
         else
             result = objectMapper.readValue(p, this.currentEntityType);
-        if (result instanceof ExpandableEntity expandableEntity) {
-            Map<String, Object> extraFields = expandableEntity.getExtraFields();
-            EntityExtensionService entityExtensionService = checkExtensionServiceExists(result);
+        if (result instanceof ExpandableEntity expandableEntity) { // check if implements ExpandableEntity
+            Map<String, Object> extraFields = expandableEntity.getExtraFields(); // get extra fields that are mapped thank to @JsonAnySetter (inside entity)
+            EntityExtensionService entityExtensionService = checkExtensionServiceExists(result); // check if service was declared
             if (extraFields != null && !extraFields.isEmpty() && entityExtensionService != null) {
+                // take the type declared in service and use object mapper to convert the map in the correct type and set it in the entity
                 EntityExtension extension = (EntityExtension) objectMapper.convertValue(extraFields, entityExtensionService.type());
                 expandableEntity.setExtension(extension);
             }

--- a/Rest-service/src/main/resources/it.water.application.properties
+++ b/Rest-service/src/main/resources/it.water.application.properties
@@ -9,6 +9,16 @@ water.rest.uploadFolder.path=${env:WATER_REST_UPLOAD_ASSETS_FOLDER:-./data/asset
 water.rest.uploadFolder.maxFileSize=${env:WATER_REST_UPLOAD_MAX_SIZE:-1000000}
 
 ################################################################
+##################### REST CORS MODULE #########################
+################################################################
+
+water.rest.cors.origins=${env:WATER_REST_CORS_ORIGINS:-}
+water.rest.cors.methods=${env:WATER_REST_CORS_METHODS:-GET,POST,PUT,DELETE,OPTIONS,PATCH}
+water.rest.cors.headers=${env:WATER_REST_CORS_HEADERS:-Authorization,Content-Type}
+water.rest.cors.credentials=${env:WATER_REST_CORS_CREDENTIALS:-false}
+water.rest.cors.maxAge=${env:WATER_REST_CORS_MAX_AGE:-3600}
+
+################################################################
 ############# REST SECURITY MODULE #############################
 ################################################################
 

--- a/Rest-spring-api/src/main/java/it/water/service/rest/spring/WaterRestSpringConfiguration.java
+++ b/Rest-spring-api/src/main/java/it/water/service/rest/spring/WaterRestSpringConfiguration.java
@@ -20,14 +20,22 @@ import it.water.service.rest.api.WaterJacksonMapper;
 import it.water.service.rest.spring.security.SpringJwtAuthenticationFilter;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
@@ -42,7 +50,20 @@ public class WaterRestSpringConfiguration implements WebMvcConfigurer {
     @Setter
     private WaterJacksonMapper waterJacksonMapper;
 
-    private MappingJackson2HttpMessageConverter jackson2HttpMessageConverter;
+    @Value("${water.rest.cors.origins}")
+    private String corsOrigins;
+
+    @Value("${water.rest.cors.methods}")
+    private String corsMethods;
+
+    @Value("${water.rest.cors.headers}")
+    private String corsHeaders;
+
+    @Value("${water.rest.cors.credentials}")
+    private boolean corsCredentials;
+
+    @Value("${water.rest.cors.maxAge}")
+    private long corsMaxAge;
 
     public WaterRestSpringConfiguration() {
         super();
@@ -62,5 +83,19 @@ public class WaterRestSpringConfiguration implements WebMvcConfigurer {
                 jacksonConverter.setObjectMapper(waterJacksonMapper.getJacksonMapper());
             }
         }
+    }
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+        Arrays.stream(corsOrigins.split(",")).map(String::trim).forEach(config::addAllowedOriginPattern);
+        Arrays.stream(corsMethods.split(",")).map(String::trim).forEach(config::addAllowedMethod);
+        Arrays.stream(corsHeaders.split(",")).map(String::trim).forEach(config::addAllowedHeader);
+        config.setAllowCredentials(corsCredentials);
+        config.setMaxAge(corsMaxAge);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return new CorsFilter(source);
     }
 }


### PR DESCRIPTION
  ## Changes                                                                                                                                                        
  1. **Added `CorsOptions` interface** to define the CORS configuration contract
  2. **Added `CorsOptionsImpl`** implementing `CorsOptions` via `ApplicationProperties`,                                                                            
     with defaults for methods, headers, credentials and maxAge
  3. **Exposed CORS settings through `RestOptions`** to centralize REST-layer configuration
  4. **Wired a highest-precedence `CorsFilter`** in Spring MVC configuration
  5. **All CORS values support environment variable overrides** with sensible defaults

  ## Files Changed
  - `CorsOptions.java` *(new)*
  - `CorsOptionsImpl.java` *(new)*
  - `RestOptions.java`
  - `SpringMvcConfiguration.java` 
  - `application.properties`
